### PR TITLE
FEAT: Change query parameters of Naver

### DIFF
--- a/src/main/naver/NaverFactory.ts
+++ b/src/main/naver/NaverFactory.ts
@@ -5,21 +5,21 @@ import { NaverViewService } from './NaverViewService';
 export class NaverFactory {
   static createCafeService(browser: Browser) {
     const NAVER_CAFE_VIEW_URL =
-      'https://search.naver.com/search.naver?where=article';
+      'https://search.naver.com/search.naver?ssc=tab.cafe.all&sm=tab_jum';
 
     return new NaverViewService(browser, NAVER_CAFE_VIEW_URL);
   }
 
   static createBlogService(browser: Browser) {
     const NAVER_BLOG_VIEW_URL =
-      'https://search.naver.com/search.naver?where=blog';
+      'https://search.naver.com/search.naver?ssc=tab.blog.all&sm=tab_jum';
 
     return new NaverViewService(browser, NAVER_BLOG_VIEW_URL);
   }
 
   static createInfluencer(browser: Browser) {
     const NAVER_INFLUENCER_URL =
-      'https://search.naver.com/search.naver?where=influencer';
+      'https://search.naver.com/search.naver?ssc=tab.influencer.chl&where=influencer&sm=tab_jum';
 
     return new InfluencerService(browser, NAVER_INFLUENCER_URL);
   }

--- a/src/main/naver/NaverServiceBase.ts
+++ b/src/main/naver/NaverServiceBase.ts
@@ -137,11 +137,9 @@ export abstract class NaverServiceBase implements NaverService {
   }
 
   private async makeBorderForCategory($searchPage: Page) {
-    const categoryQuery = new URL($searchPage.url()).searchParams.get('where');
+    const categoryQuery = new URL($searchPage.url()).searchParams.get('ssc');
 
-    const $categoryBox = await $searchPage.$(
-      `a[href*="where=${categoryQuery}"]`
-    );
+    const $categoryBox = await $searchPage.$(`a[href*="ssc=${categoryQuery}"]`);
 
     if (!$categoryBox) {
       throw new Error(


### PR DESCRIPTION
## What?
- Change query parameters of Naver

## Why?
- 기존 URL의 경우에 네이버에서 지정한 특정 검색어의 경우는 블로그, 인플루언서 등이 결과 페이지가 아닌 홈페이지, 스마트스토어 등이 포함된 다른 검색 결과가 나옴

## How?
- query parameter를 기존 where에서 ssc 기준으로 변경
- 스크린샷 촬영 시 현재 검색중인 카테고리를 결정하는 로직이 query parameter에 의존하고 있으므로 해당 부분도 변경

## Anything Else?
